### PR TITLE
fix: extractMostOcurring was always returning the first element

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -48,7 +48,6 @@ export function extractMostOccuring<T extends string | number | symbol>(elements
         maxCount = modeMap[el];
       }
     }
-    return maxEl;
   }
   return maxEl;
 }


### PR DESCRIPTION
The extra `return maxEl` shouldn't be there